### PR TITLE
addressing behavior in transforms with dimensionless positions

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -18,13 +18,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Setup Environment
-        run: |
-          pip install pre-commit
-      - name: Linting
-        run: |
-          pre-commit install
-          pre-commit run -a
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: -a
   datacache:
     name: Cache Data
     runs-on: ubuntu-latest

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -18,9 +18,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: -a
+      - name: Setup Environment
+        run: |
+          pip install pre-commit
+      - name: Linting
+        run: |
+          pre-commit install
+          pre-commit run -a
   datacache:
     name: Cache Data
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
             - flake8-comprehensions
             - flake8-pytest
     - repo: https://github.com/psf/black
-      rev: 20.8b1
+      rev: 22.3.0
       hooks:
           - id: black
             language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 exclude: '(^lunarsky/data/)'
 
 repos:
-    - repo: git://github.com/pre-commit/pre-commit-hooks
-      rev: v2.5.0
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.3.0
       hooks:
           - id: trailing-whitespace
           - id: check-ast

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '(^lunarsky/data/*)'
+exclude: '(^lunarsky/data/)'
 
 repos:
     - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ## Fixed
+- Accept tuple for location in Time class (in this case, assumes EarthLocation)
+- Use newer PCK file in unit test with Earth positioning.
+- Match behavior of astropy when transforming non-unit cartesian positions without units (treat as unitspherical using direction info only)
 - Now tracking available lunar station_ids, instead of incrementing a counter naively.
 
 ## [0.1.2] -- 2022-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,14 @@
 ## Unreleased
 
 ## Fixed
+- Updated version of pre-commit-hooks used
 - Accept tuple for location in Time class (in this case, assumes EarthLocation)
 - Use newer PCK file in unit test with Earth positioning.
 - Match behavior of astropy when transforming non-unit cartesian positions without units (treat as unitspherical using direction info only)
 - Now tracking available lunar station_ids, instead of incrementing a counter naively.
+
+## Deprecated
+- Dropping support for Python 3.6
 
 ## [0.1.2] -- 2022-01-17
 

--- a/lunarsky/mcmf.py
+++ b/lunarsky/mcmf.py
@@ -94,6 +94,9 @@ def make_transform(coo, toframe):
 
     newrepr = coo_cart.transform(mats).reshape(shape_out)
 
+    if is_unitspherical:
+        newrepr = newrepr.represent_as(UnitSphericalRepresentation)
+
     return toframe.realize_frame(newrepr)
 
 

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -10,7 +10,7 @@ from astropy.coordinates.representation import (
 )
 from astropy.coordinates.attributes import Attribute
 
-from .spice_utils import remove_topo
+from .spice_utils import remove_topo, LUNAR_RADIUS
 
 __all__ = ["MoonLocation", "MoonLocationAttribute"]
 
@@ -113,7 +113,7 @@ class MoonLocation(u.Quantity):
     _location_dtype = np.dtype({"names": ["x", "y", "z"], "formats": [np.float64] * 3})
     _array_dtype = np.dtype((np.float64, (3,)))
 
-    _lunar_radius = 1737.1e3  # m
+    _lunar_radius = LUNAR_RADIUS
 
     # Manage the set of defined ephemerides.
     # Class attributes only

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -282,7 +282,7 @@ class MoonLocation(u.Quantity):
         the mean position of the "sub-Earth" point on the lunar surface.
 
         """
-        lon = Longitude(lon, u.degree, wrap_angle=180 * u.degree, copy=False)
+        lon = Longitude(lon, u.degree, copy=False).wrap_at(180 * u.degree)
         lat = Latitude(lat, u.degree, copy=False)
         # don't convert to m by default, so we can use the height unit below.
         if not isinstance(height, u.Quantity):

--- a/lunarsky/tests/test_spice.py
+++ b/lunarsky/tests/test_spice.py
@@ -64,8 +64,7 @@ def test_spice_earth(grcat):
     )
 
     # One more kernel is needed for the ITRF93 frame.
-    # kname = "pck/earth_latest_high_prec.bpc"
-    kname = "pck/earth_000101_221031_220807.bpc"
+    kname = "pck/earth_latest_high_prec.bpc"
     _naif_kernel_url = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels"
     kurl = [_naif_kernel_url + "/" + kname]
     kernpath = download_files_in_parallel(

--- a/lunarsky/tests/test_spice.py
+++ b/lunarsky/tests/test_spice.py
@@ -64,7 +64,8 @@ def test_spice_earth(grcat):
     )
 
     # One more kernel is needed for the ITRF93 frame.
-    kname = "pck/earth_latest_high_prec.bpc"
+    # kname = "pck/earth_latest_high_prec.bpc"
+    kname = "pck/earth_000101_221031_220807.bpc"
     _naif_kernel_url = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels"
     kurl = [_naif_kernel_url + "/" + kname]
     kernpath = download_files_in_parallel(

--- a/lunarsky/tests/test_time.py
+++ b/lunarsky/tests/test_time.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.coordinates import ICRS
+from astropy.coordinates import ICRS, EarthLocation
 from astropy.time import TimeDelta
 import pytest
 
@@ -23,3 +23,15 @@ def test_sidereal_time_calculation(lat, lon):
         src = SkyCoord(alt="90d", az="0d", frame="lunartopo", obstime=tt, location=loc)
         lst = tt.sidereal_time("mean")
         assert np.isclose(lst.deg, src.transform_to(ICRS()).ra.deg, atol=1e-4)
+
+
+def test_earthloc():
+    lat = -30.0
+    lon = 127.0
+
+    t0 = Time(
+        "2020-01-01T00:00:00", location=EarthLocation.from_geodetic(lon=lon, lat=lat)
+    )
+    t1 = Time("2020-01-01T00:00:00", location=(lon, lat))
+
+    assert t0.location == t1.location

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -279,7 +279,7 @@ def test_finite_vs_spherical():
 
     loc = lunarsky.MoonLocation.from_selenodetic(lon=180 * un.deg, lat=0, height=0)
     altaz_with_units = with_units.transform_to(lunarsky.LunarTopo(location=loc))
-    with pytest.warns(exceptions.AstropyUserWarning, match="Coordinate vectors do not "):
+    with pytest.warns(exceptions.AstropyUserWarning, match="Coordinates do not "):
         altaz_sans_units = sans_units.transform_to(lunarsky.LunarTopo(location=loc))
 
     radius = lunarsky.spice_utils.LUNAR_RADIUS * un.m

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from lunarsky.time import Time, TimeDelta
 import astropy.coordinates as ac
 from astropy import units as un
-from astropy.utils import IncompatibleShapeError
+from astropy.utils import IncompatibleShapeError, exceptions
 from astropy.tests.helper import assert_quantity_allclose
 import lunarsky
 import pytest
@@ -279,7 +279,8 @@ def test_finite_vs_spherical():
 
     loc = lunarsky.MoonLocation.from_selenodetic(lon=180 * un.deg, lat=0, height=0)
     altaz_with_units = with_units.transform_to(lunarsky.LunarTopo(location=loc))
-    altaz_sans_units = sans_units.transform_to(lunarsky.LunarTopo(location=loc))
+    with pytest.warns(exceptions.AstropyUserWarning, match="Coordinate vectors do not "):
+        altaz_sans_units = sans_units.transform_to(lunarsky.LunarTopo(location=loc))
 
     radius = lunarsky.spice_utils.LUNAR_RADIUS * un.m
     assert np.all(altaz_with_units.distance < radius + R0 * un.km)

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -25,6 +25,7 @@ jd_4mo = t0 + TimeDelta(np.linspace(0, 4 * 28 * 24 * 3600.0, 100), format="sec")
 
 @pytest.mark.parametrize("time", jd_10yr)
 @pytest.mark.parametrize("lat,lon", latlons_grid)
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
 def test_icrs_to_topo_long_time(time, lat, lon, grcat):
     # Check that the following transformation paths are equivalent:
     #   ICRS -> MCMF -> TOPO
@@ -48,9 +49,9 @@ def test_icrs_to_topo_long_time(time, lat, lon, grcat):
     "time, lat, lon",
     [
         (t0, 11.2, 1.4),
-        (t0, (10.3, 11.2), (0.0, 1.4)),
+        (t0, [10.3, 11.2], [0.0, 1.4]),
         (jd_4mo[:2], 10.3, 0.0),
-        (jd_4mo[:2], (10.3, 11.2), (0.0, 1.4)),
+        (jd_4mo[:2], [10.3, 11.2], [0.0, 1.4]),
     ],
 )
 def test_transform_loops(obj, path, time, lat, lon):
@@ -84,6 +85,7 @@ def test_topo_to_topo():
     assert new.az.deg == 90
 
 
+@pytest.mark.filterwarnings("ignore::erfa.ErfaWarning")
 def test_mcmf_to_mcmf():
     # Transform MCMF positions to MCMF frame half a lunar sidereal day later.
     # Assert that the new positions are roughly close to 180 deg from the original.

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -53,7 +53,7 @@ class Time(astropy.time.Time):
 
     def sidereal_time(self, kind, longitude=None, model=None):
         # Currently returns the zenith RA as the LST.
-        if self.location is None or self.location is EarthLocation:
+        if self.location is None or isinstance(self.location, EarthLocation):
             return super().sidereal_time(kind, longitude=longitude, model=model)
 
         if model is not None:

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -33,7 +33,7 @@ class Time(astropy.time.Time):
     ):
 
         super_loc = None
-        if isinstance(location, EarthLocation):
+        if isinstance(location, (EarthLocation, tuple)):
             super_loc = location
 
         super().__init__(

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.representation import (
     SphericalRepresentation,
@@ -6,7 +7,7 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
     CartesianRepresentation,
 )
-from astropy.utils import check_broadcast
+from astropy.utils import check_broadcast, exceptions
 from astropy.coordinates.baseframe import (
     BaseCoordinateFrame,
     base_doc,
@@ -185,6 +186,12 @@ def make_transform(coo, toframe):
     newrepr = coo_cart.transform(mats).reshape(shape_out)
 
     if is_unitspherical:
+        if np.any(newrepr.norm() > 1.0):
+            warnings.warn(
+                "Coordinates do not all have unit magnitude, but will be treated as unit spherical,"
+                "Define coordinates as Quantity or normalize to remove this warning.",
+                exceptions.AstropyUserWarning,
+            )
         newrepr = newrepr.represent_as(UnitSphericalRepresentation)
 
     return toframe.realize_frame(newrepr)

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -180,10 +180,12 @@ def make_transform(coo, toframe):
             )
             * un.km
         )
-
         coo_cart -= CartesianRepresentation((orig_posvel.T)[:3])
 
     newrepr = coo_cart.transform(mats).reshape(shape_out)
+
+    if is_unitspherical:
+        newrepr = newrepr.represent_as(UnitSphericalRepresentation)
 
     return toframe.realize_frame(newrepr)
 

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -186,7 +186,7 @@ def make_transform(coo, toframe):
     newrepr = coo_cart.transform(mats).reshape(shape_out)
 
     if is_unitspherical:
-        if np.any(newrepr.norm() > 1.0):
+        if not np.allclose(newrepr.norm(), 1.0):
             warnings.warn(
                 "Coordinates do not all have unit magnitude, but will be treated as unit spherical,"
                 "Define coordinates as Quantity or normalize to remove this warning.",

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -125,6 +125,9 @@ def make_transform(coo, toframe):
         obstime = toframe.obstime
         location = toframe.location
 
+    if location is None:
+        raise ValueError("location must be defined for LunarTopo transformations")
+
     # Initialize station_ids if not defined.
     if location.station_ids == []:
         location.__class__._set_site_id(location)


### PR DESCRIPTION
When given a SkyCoord in the form of dimensionless cartesian coordinates, astropy will ignore the magnitude of the coordinate vectors. These changes mimic this behavior in transformations.

closes #18 .

TODO

- [x] Add warning when magnitude of dimensionless vectors is not unity.