### PR TITLE
use latest pypi action to switch node16 instead of node12

### DIFF
--- a/.github/workflows/pypirelease.yaml
+++ b/.github/workflows/pypirelease.yaml
@@ -3,6 +3,8 @@ name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 on:
   release:
     types: [created]
+  workflow_dispatch:
+
 
 jobs:
   build-n-publish:
@@ -35,6 +37,7 @@ jobs:
         user: __token__
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        skip_existing: true
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1.5.1

--- a/.github/workflows/pypirelease.yaml
+++ b/.github/workflows/pypirelease.yaml
@@ -29,7 +29,7 @@ jobs:
         --outdir dist/
         .
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.5.1
       if: startsWith(github.ref, 'refs/tags')
       with:
         user: __token__
@@ -37,7 +37,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@release/v1.5.1
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Update to avoid warnings about old version