### PR TITLE
Ellipsoids

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
          fetch-depth: 1
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Setup Environment
         run: |
           pip install pre-commit
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
       rev: 22.3.0
       hooks:
           - id: black
-            language_version: python3.8
+            language_version: python3.9
             args:
               - --line-length=90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+## Added
+- Support for ellipsoid models for selenodetic coordinates (non-spherical)
+
 ## [0.2.0] -- 2022-10-12
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.2.2] -- 2022-03-19
 
 ## Added
 - Support for ellipsoid models for selenodetic coordinates (non-spherical)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Added
 - Support for ellipsoid models for selenodetic coordinates (non-spherical)
 
+## Deprecated
+- Removed support for Python < 3.9. Astropy >= 6.0 is required for ellipsoid support
+
 ## [0.2.0] -- 2022-10-12
 
 ## Fixed

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -379,7 +379,7 @@ class MoonLocation(u.Quantity):
         selenodetic = SELENOIDS[ellipsoid](lon, lat, height, copy=False)
         xyz = selenodetic.to_cartesian().get_xyz(xyz_axis=-1) << height.unit
         self = xyz.view(cls._location_dtype, cls).reshape(selenodetic.shape)
-        self._ellipsoid = ellipsoid
+        self.ellipsoid = ellipsoid
         return self
 
     def __str__(self):

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -81,16 +81,6 @@ def _check_ellipsoid(ellipsoid=None, default="SPHERE"):
     return ellipsoid
 
 
-def _add_rm_ellipsoid(ellipsoid, name, add=True):
-    """Add or remove an ellipsoid class from SELENOIDS.
-    Needed for testing."""
-    global SELENOIDS
-    if add:
-        SELENOIDS[name] = ellipsoid
-    else:
-        SELENOIDS.pop(name, None)
-
-
 class MoonLocationInfo(QuantityInfoBase):
     """
     Container for meta information like name, description, format.  This is

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -23,6 +23,14 @@ class SPHERESelenodeticRepresentation(BaseGeodeticRepresentation):
     _equatorial_radius = LUNAR_RADIUS * u.m 
     _flattening = 0.0
 
+class GSFCSelenodeticRepresentation(BaseGeodeticRepresentation):
+    """Lunar ellipsoid from NASA/GSFC "Planetary Fact Sheet"
+
+       https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
+    """
+    _equatorial_radius = 1738.1 * u.m
+    _flattening = 0.0012
+
 class GRAIL23SelenodeticRepresentation(BaseGeodeticRepresentation):
     """Lunar ellipsoid defined by gravimetry of GRAIL data.
 
@@ -45,6 +53,7 @@ class CE1LAM10SelenodeticRepresentation(BaseGeodeticRepresentation):
 # Define reference ellipsoids
 LUNAR_ELLIPSOIDS = {
     "SPHERE" : SPHERESelenodeticRepresentation,
+    "GSFC" : GSFCSelenodeticRepresentation,
     "GRAIL23" : GRAIL23SelenodeticRepresentation,
     "CE-1-LAM-GEO" : CE1LAM10SelenodeticRepresentation,
 }

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -7,7 +7,6 @@ from astropy.coordinates.earth import GeodeticLocation
 from astropy.coordinates.representation.geodetic import BaseGeodeticRepresentation
 from astropy.coordinates.representation import (
     CartesianRepresentation,
-    SphericalRepresentation,
 )
 from astropy.coordinates.attributes import Attribute
 
@@ -17,29 +16,36 @@ LUNAR_RADIUS = 1737.1e3  # m
 
 __all__ = ["MoonLocation", "MoonLocationAttribute"]
 
+
 class SPHERESelenodeticRepresentation(BaseGeodeticRepresentation):
     """Lunar ellipsoid as a sphere
 
-        Radius defined by lunarsky.spice_utils.LUNAR_RADIUS
+    Radius defined by lunarsky.spice_utils.LUNAR_RADIUS
     """
-    _equatorial_radius = LUNAR_RADIUS * u.m 
+
+    _equatorial_radius = LUNAR_RADIUS * u.m
     _flattening = 0.0
+
 
 class GSFCSelenodeticRepresentation(BaseGeodeticRepresentation):
     """Lunar ellipsoid from NASA/GSFC "Planetary Fact Sheet"
 
-       https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
+    https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
     """
+
     _equatorial_radius = 1738.1e3 * u.m
     _flattening = 0.0012
+
 
 class GRAIL23SelenodeticRepresentation(BaseGeodeticRepresentation):
     """Lunar ellipsoid defined by gravimetry of GRAIL data.
 
     https://doi.org/10.1007/s40328-023-00415-w
     """
+
     _equatorial_radius = 1737576.6 * u.m
     _flattening = 0.000305
+
 
 class CE1LAM10SelenodeticRepresentation(BaseGeodeticRepresentation):
     """Lunar ellipsoid from Chang'e 1 laser altimetry.
@@ -48,16 +54,17 @@ class CE1LAM10SelenodeticRepresentation(BaseGeodeticRepresentation):
 
     https://doi.org/10.1007/s11430-010-4060-6
     """
+
     _equatorial_radius = 1737.632 * u.km
-    _flattening = 1/973.463
+    _flattening = 1 / 973.463
 
 
 # Define reference ellipsoids
 SELENOIDS = {
-    "SPHERE" : SPHERESelenodeticRepresentation,
-    "GSFC" : GSFCSelenodeticRepresentation,
-    "GRAIL23" : GRAIL23SelenodeticRepresentation,
-    "CE-1-LAM-GEO" : CE1LAM10SelenodeticRepresentation,
+    "SPHERE": SPHERESelenodeticRepresentation,
+    "GSFC": GSFCSelenodeticRepresentation,
+    "GRAIL23": GRAIL23SelenodeticRepresentation,
+    "CE-1-LAM-GEO": CE1LAM10SelenodeticRepresentation,
 }
 
 
@@ -242,7 +249,9 @@ class MoonLocation(u.Quantity):
             raise ValueError("Too many unique MoonLocation objects open at once.")
 
         for llh in llh_arr:
-            lonlatheight = "_".join(["{:.4f}".format(ll) for ll in llh] + [inst._ellipsoid])
+            lonlatheight = "_".join(
+                ["{:.4f}".format(ll) for ll in llh] + [inst._ellipsoid]
+            )
             if lonlatheight not in cls._existing_locs:
                 new_stat_id = cls._avail_stat_ids.pop()
                 cls._existing_locs.append(lonlatheight)
@@ -451,9 +460,7 @@ class MoonLocation(u.Quantity):
         return SelenodeticLocation(
             Longitude(llh.lon, u.degree, wrap_angle=180.0 * u.degree, copy=False),
             Latitude(llh.lat, u.degree, copy=False),
-            u.Quantity(
-                llh.height, self.unit, copy=False
-            ),
+            u.Quantity(llh.height, self.unit, copy=False),
         )
 
     @property

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -12,13 +12,8 @@ from .mcmf import MCMF
 from .data import DATA_PATH
 
 _J2000 = Time("J2000")
-LUNAR_RADIUS = 1737.1e3  # m
 
 TEMPORARY_KERNEL_DIR = tempfile.TemporaryDirectory()
-
-# TODO --> Look for updated kernels and coordinate definitions.
-#          Use https://naif.jpl.nasa.gov/pub/naif/MER/misc/pck/pck00008.tpc for lunar radii
-
 
 def check_is_loaded(search):
     """
@@ -73,7 +68,7 @@ def furnish_kernels():
     return kernel_paths
 
 
-def lunar_surface_ephem(latitude, longitude, station_num=98):
+def lunar_surface_ephem(pos_x, pos_y, pos_z, station_num=98):
     """
     Make an SPK for the point on the lunar surface
 
@@ -81,10 +76,8 @@ def lunar_surface_ephem(latitude, longitude, station_num=98):
 
     Parameters
     ----------
-    latitude: float
-        Mean-Earth frame selenodetic latitude in degrees.
-    longitude: float
-        Mean-Earth frame selenodetic longitude in degrees.
+    pos_x, pos_y, pos_z: float
+        MCMF frame cartesian position in km
     station_num: int
         Station number
 
@@ -95,15 +88,10 @@ def lunar_surface_ephem(latitude, longitude, station_num=98):
     """
     point_id = 301000 + station_num
 
-    lat = np.radians(latitude)
-    lon = np.radians(longitude)
     ets = np.array([spice.str2et("1950-01-01"), spice.str2et("2150-01-01")])
-    pos_mcmf = spice.latrec(
-        LUNAR_RADIUS / 1e3, lon, lat
-    )  # TODO Use MoonLocation instead?
 
     states = np.zeros((len(ets), 6))
-    states[:, :3] = np.repeat(pos_mcmf[None, :], len(ets), axis=0)
+    states[:, :3] = np.repeat([[pos_x], [pos_y], [pos_z]], len(ets), axis=1).T
 
     center = 301
     frame = "MOON_ME"

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -15,6 +15,7 @@ _J2000 = Time("J2000")
 
 TEMPORARY_KERNEL_DIR = tempfile.TemporaryDirectory()
 
+
 def check_is_loaded(search):
     """
     Search the kernel pool variable names for a given string.

--- a/lunarsky/tests/test_moon.py
+++ b/lunarsky/tests/test_moon.py
@@ -2,10 +2,11 @@ import pytest
 import copy
 import numpy as np
 import astropy.units as unit
-from astropy.coordinates import Longitude, Latitude
+from astropy.coordinates import Longitude, Latitude, SphericalRepresentation, SphericalDifferential
 from astropy.tests.helper import quantity_allclose
+from astropy.coordinates.tests.test_representation import representation_equal
 from lunarsky import MoonLocation, MoonLocationAttribute, MCMF
-from lunarsky.moon import SELENOIDS
+from lunarsky.moon import SELENOIDS, MoonLocationInfo
 
 
 class TestsWithObject:
@@ -21,7 +22,7 @@ class TestsWithObject:
         self.lat = Latitude([+0.0, 30.0, 60.0, +90.0, -90.0, -60.0, -30.0, 0.0], unit.deg)
         self.h = unit.Quantity([0.1, 0.5, 1.0, -0.5, -1.0, +4.2, -11.0, -0.1], unit.m)
         self.location = MoonLocation.from_selenodetic(self.lon, self.lat, self.h)
-        self.x, self.y, self.z = self.location.to_selenocentric()
+        self.x, self.y, self.z = self.location.selenocentric
 
     def test_input(self):
         cartesian = MoonLocation(self.x, self.y, self.z)
@@ -67,6 +68,10 @@ class TestsWithObject:
         # inconsistent shape
         with pytest.raises(ValueError):
             MoonLocation.from_selenodetic(self.lon, self.lat, self.h[:5])
+
+        # invalid ellipsoid
+        with pytest.raises(ValueError):
+            loc = MoonLocation.from_selenodetic(self.lon, self.lat, self.h, ellipsoid="INVALID")
 
     def test_attributes(self):
         assert np.allclose(self.location.height, self.h)

--- a/lunarsky/tests/test_moon.py
+++ b/lunarsky/tests/test_moon.py
@@ -2,11 +2,13 @@ import pytest
 import copy
 import numpy as np
 import astropy.units as unit
-from astropy.coordinates import Longitude, Latitude, SphericalRepresentation, SphericalDifferential
+from astropy.coordinates import (
+    Longitude,
+    Latitude,
+)
 from astropy.tests.helper import quantity_allclose
-from astropy.coordinates.tests.test_representation import representation_equal
 from lunarsky import MoonLocation, MoonLocationAttribute, MCMF
-from lunarsky.moon import SELENOIDS, MoonLocationInfo
+from lunarsky.moon import SELENOIDS
 
 
 class TestsWithObject:
@@ -71,7 +73,7 @@ class TestsWithObject:
 
         # invalid ellipsoid
         with pytest.raises(ValueError):
-            loc = MoonLocation.from_selenodetic(self.lon, self.lat, self.h, ellipsoid="INVALID")
+            MoonLocation.from_selenodetic(self.lon, self.lat, self.h, ellipsoid="INVALID")
 
     def test_attributes(self):
         assert np.allclose(self.location.height, self.h)

--- a/lunarsky/tests/test_spice.py
+++ b/lunarsky/tests/test_spice.py
@@ -108,12 +108,12 @@ def test_topo_kernel_setup():
 
     for filepath in lunarsky.spice_utils.KERNEL_PATHS:
         spice.furnsh(filepath)
-    lat, lon = 30, 20
+    loc = lunarsky.MoonLocation.from_selenodetic(lat="30d", lon="20d")
     station_name, idnum, frame_specs, latlon = lunarsky.spice_utils.topo_frame_def(
-        lat, lon, moon=True
+        loc.lat.deg, loc.lon.deg, moon=True
     )
     statnum = idnum - 1301000
-    lunarsky.topo._spice_setup(lat, lon, [statnum])
+    lunarsky.topo._spice_setup(loc, [statnum])
     try:
         assert lunarsky.spice_utils.check_is_loaded("*{}*".format(idnum))
     finally:

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -8,6 +8,11 @@ from astropy.tests.helper import assert_quantity_allclose
 import lunarsky
 import pytest
 
+try:
+    from astropy.coordinates.angles.utils import angular_separation
+except ImportError:
+    from astropy.coordinates.angle_utilities import angular_separation
+
 # Lunar station positions
 Nangs = 3
 latitudes = np.linspace(-90, 90, Nangs)
@@ -97,7 +102,7 @@ def test_mcmf_to_mcmf():
     )
     sph0 = src.spherical
     sph1 = orig_pos.spherical
-    res = ac.angle_utilities.angular_separation(
+    res = angular_separation(
         sph0.lon, sph0.lat, sph1.lon, sph1.lat
     ).to("deg")
     assert_quantity_allclose(res, 177 * un.deg, atol=5 * un.deg)
@@ -238,7 +243,7 @@ def test_incompatible_shape_error(Nt, Nl, success):
     if success:
         lunarsky.LunarTopo(location=locs, obstime=times)
     else:
-        with pytest.raises(ValueError, match="non-scalar attributes"):
+        with pytest.raises(ValueError, match="non-scalar data and/or attributes"):
             lunarsky.LunarTopo(location=locs, obstime=times)
 
 

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -22,7 +22,8 @@ latlons_grid = [(lat, lon) for lon in longitudes for lat in latitudes]
 
 # Avoiding poles:
 latlons_grid_nopole = [
-    (lat, lon) for lon in np.linspace(0.1, 360, Nangs, endpoint=False)
+    (lat, lon)
+    for lon in np.linspace(0.1, 360, Nangs, endpoint=False)
     for lat in np.linspace(-70.0, 70.0, Nangs, endpoint=False)
 ]
 
@@ -110,9 +111,7 @@ def test_mcmf_to_mcmf():
     )
     sph0 = src.spherical
     sph1 = orig_pos.spherical
-    res = angular_separation(
-        sph0.lon, sph0.lat, sph1.lon, sph1.lat
-    ).to("deg")
+    res = angular_separation(sph0.lon, sph0.lat, sph1.lon, sph1.lat).to("deg")
     assert_quantity_allclose(res, 177 * un.deg, atol=5 * un.deg)
     # Tolerance to allow for lunar precession / nutation.
 
@@ -288,7 +287,7 @@ def test_finite_vs_spherical(ell):
     # Check consistency with ellipsoid equatorial radius
     # Assumes infinite distance if no unit given, as astropy does.
 
-    R0 = 404789     # km
+    R0 = 404789  # km
     xyz = np.array([[R0, -R0], [0, 0], [0, 0]])
     with_units = lunarsky.SkyCoord(lunarsky.MCMF(*(xyz * un.km)))
     sans_units = lunarsky.SkyCoord(lunarsky.MCMF(*(xyz)))
@@ -304,6 +303,7 @@ def test_finite_vs_spherical(ell):
     assert np.all(altaz_with_units.distance == dists)
     assert_quantity_allclose(altaz_sans_units.distance, 1.0)
 
+
 @pytest.mark.parametrize("ell", SELENOIDS)
 @pytest.mark.parametrize("lat,lon", latlons_grid_nopole)
 def test_topo_zenith_shift(ell, lat, lon):
@@ -314,7 +314,8 @@ def test_topo_zenith_shift(ell, lat, lon):
     # Checking that the ellipsoid is interpreted correctly
 
     # This test is a little sketchy... will need to review this later.
-    #   Some discrepancies for GRAIL23 selenoid when the source distance is large. Chooseing 1000 km for now.
+    #   Some discrepancies for GRAIL23 selenoid when the source distance is large.
+    #       Choosing 1000 km for now.
     #   Also fails near poles.
 
     # Comparing against the SPHERE ellipsoid. Test fails for this due to divide by zero
@@ -324,11 +325,20 @@ def test_topo_zenith_shift(ell, lat, lon):
     lat *= un.deg
     lon *= un.deg
 
-    loc0 = lunarsky.MoonLocation.from_selenodetic(lon, lat, ellipsoid='SPHERE')     # For reference.
-    loc1 = lunarsky.MoonLocation.from_selenodetic(lon, lat, ellipsoid=ell)       # Same lat/lon = different place for different ellipsoid
+    loc0 = lunarsky.MoonLocation.from_selenodetic(
+        lon, lat, ellipsoid="SPHERE"
+    )  # For reference.
+    loc1 = lunarsky.MoonLocation.from_selenodetic(
+        lon, lat, ellipsoid=ell
+    )  # Same lat/lon = different place for different ellipsoid
 
     # Zenith source at finite distance over loc0.
-    src0 = lunarsky.SkyCoord(alt='90d', az='0d', distance=1e3 * un.km, frame=lunarsky.LunarTopo(location=loc0, obstime=Time.now()))
+    src0 = lunarsky.SkyCoord(
+        alt="90d",
+        az="0d",
+        distance=1e3 * un.km,
+        frame=lunarsky.LunarTopo(location=loc0, obstime=Time.now()),
+    )
     src1 = src0.transform_to(lunarsky.LunarTopo(location=loc1))
 
     # Law of sines:
@@ -338,9 +348,8 @@ def test_topo_zenith_shift(ell, lat, lon):
     R1 = loc1.mcmf.cartesian.norm()
     lat_cen = loc1.mcmf.spherical.lat
     lat_det = loc1.lat
-    diff = (src1.distance / np.sin((np.abs(lat_det - lat_cen)).rad)) - (R1 / np.sin(src1.zen.rad))
     assert_quantity_allclose(
         src1.distance / np.sin((np.abs(lat_det - lat_cen)).rad),
         R1 / np.sin(src1.zen.rad),
-        atol=1*un.km,
+        atol=1 * un.km,
     )

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -87,16 +87,17 @@ class LunarTopo(BaseCoordinateFrame):
 # Helper functions
 # -----------------
 
+
 def _spice_setup(locations, station_ids):
     for li, loc in enumerate(np.atleast_1d(locations)):
         sid = int(station_ids[li])
         frameloaded = check_is_loaded(f"FRAME_LUNAR-TOPO-{sid}")
         if not frameloaded:
             lunar_surface_ephem(
-                loc.x.to_value('km'),
-                loc.y.to_value('km'),
-                loc.z.to_value('km'),
-                station_num=sid
+                loc.x.to_value("km"),
+                loc.y.to_value("km"),
+                loc.z.to_value("km"),
+                station_num=sid,
             )  # Furnishes SPK for lunar surface point
             station_name, idnum, frame_specs, latlon = topo_frame_def(
                 loc.lat.deg, loc.lon.deg, moon=True, station_num=sid
@@ -132,7 +133,6 @@ def make_transform(coo, toframe):
     shape_out = check_broadcast(coo.shape, ets.shape, location.shape)
 
     # Set up SPICE ephemerides and frame details
-    ## Use MCMF cartesian position
     _spice_setup(location, stat_ids)
 
     ets_ids = np.atleast_2d(np.stack(np.broadcast_arrays(ets, stat_ids)).T)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup_args = {
     "test_suite": "pytest",
     "tests_require": ["pytest"],
     "setup_requires": ["pytest-runner", "setuptools_scm"],
-    "install_requires": ["numpy>=1.15", "astropy>3.0", "spiceypy", "jplephem"],
+    "install_requires": ["numpy>=1.15", "astropy>=6.0.0", "spiceypy", "jplephem"],
     "classifiers": [
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Switch to using ellipsoid models in defining selenodetic coordinates. Ellipsoids are called "selenoids" in analogy with "geoids".

Updates some tests accordingly. This is needed for corresponding changes in pyuvdata.