### PR TITLE
avoid deprecation warning in astropy.time.Time

### DIFF
--- a/lunarsky/tests/test_time.py
+++ b/lunarsky/tests/test_time.py
@@ -13,7 +13,7 @@ def test_sidereal_time_calculation(lat, lon):
 
     t0 = Time.now()
     loc = MoonLocation.from_selenodetic(lon, lat, 0)
-    t0.location = loc
+    t0 = Time(t0, location=loc)
 
     Ntimes = 200
     Ndays = 28

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import astropy
+from astropy import version
 from astropy.coordinates import EarthLocation, Longitude
 
 from .moon import MoonLocation
@@ -49,7 +50,10 @@ class Time(astropy.time.Time):
         )
 
         if isinstance(location, MoonLocation):
-            self.location = location
+            if (version.major == 6 and version.minor >= 1) or version.major > 6:
+                self._location = location
+            else:
+                self.location = location
 
     def sidereal_time(self, kind, longitude=None, model=None):
         # Currently returns the zenith RA as the LST.

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -50,6 +50,8 @@ class Time(astropy.time.Time):
         )
 
         if isinstance(location, MoonLocation):
+            # Avoids a deprecation warning in astropy >= 6.1, while 
+            # maintaining compatibility with earlier versions.
             if (version.major == 6 and version.minor >= 1) or version.major > 6:
                 self._location = location
             else:

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -50,9 +50,8 @@ class Time(astropy.time.Time):
         )
 
         if isinstance(location, MoonLocation):
-            # Avoids a deprecation warning in astropy >= 6.1, while 
-            # maintaining compatibility with earlier versions.
             if (version.major == 6 and version.minor >= 1) or version.major > 6:
+                # In astropy >= 6.1, time.Time.location is a property that shouldn't be set directly
                 self._location = location
             else:
                 self.location = location


### PR DESCRIPTION
Assigning to the location attribute will be deprecated in the future. Some logic in `lunarsky.time.Time` was required to properly handle dimensionless locations (which astropy takes to be `EarthLocation`s), and that required directly setting the location attribute.

This removes the deprecation warning in astropy >= 6.1, while maintaining compatibility with earlier versions.

Closes #27 