### PR TITLE
compatibility with numpy=2 _and_ with astropy6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## [0.2.4] -- 2024-06-26
+
+## [0.2.5] -- 2024-06-26
 
 ## Fixed
+- Maintain compatibility with astropy 6.0.0
 - Compatibility with numpy 2.0
 
 

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -9,9 +9,11 @@ from astropy.coordinates.representation import (
     CartesianRepresentation,
 )
 from astropy.coordinates.attributes import Attribute
-from astropy.utils.compat import COPY_IF_NEEDED
+from astropy.utils import minversion
 
 from .spice_utils import remove_topo
+
+COPY_IF_NEEDED = None if minversion(np, "2.0") else False
 
 LUNAR_RADIUS = 1737.1e3  # m
 

--- a/lunarsky/time.py
+++ b/lunarsky/time.py
@@ -3,10 +3,9 @@
 import numpy as np
 import astropy
 from astropy import version
-from astropy.utils.compat import COPY_IF_NEEDED
 from astropy.coordinates import EarthLocation, Longitude
 
-from .moon import MoonLocation
+from .moon import MoonLocation, COPY_IF_NEEDED
 import spiceypy as spice
 
 __all__ = ["Time", "TimeDelta"]


### PR DESCRIPTION
Patch to ensure lunarsky is still compatible with astropy 6.0.0 and with astropy 6.1.1