### PR TITLE
Replace deprecated astropy check_broadcast with np.broadcast_shapes

### DIFF
--- a/lunarsky/mcmf.py
+++ b/lunarsky/mcmf.py
@@ -5,7 +5,6 @@ from astropy.coordinates.representation import (
     CartesianDifferential,
     UnitSphericalRepresentation,
 )
-from astropy.utils import check_broadcast
 from astropy.coordinates.baseframe import (
     BaseCoordinateFrame,
     base_doc,
@@ -69,7 +68,7 @@ def make_transform(coo, toframe):
 
     # Make arrays
     ets = np.atleast_1d((obstime - _J2000).sec)
-    shape_out = check_broadcast(coo.shape, ets.shape)
+    shape_out = np.broadcast_shapes(coo.shape, ets.shape)
 
     coo_cart = coo.cartesian
 

--- a/lunarsky/tests/test_transforms.py
+++ b/lunarsky/tests/test_transforms.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from lunarsky.time import Time, TimeDelta
 import astropy.coordinates as ac
 from astropy import units as un
-from astropy.utils import IncompatibleShapeError, exceptions
+from astropy.utils import exceptions
 from astropy.tests.helper import assert_quantity_allclose
 import lunarsky
 from lunarsky.moon import SELENOIDS
@@ -277,7 +277,7 @@ def test_incompatible_transform(fromframe):
         )
     )
     src = lunarsky.SkyCoord(coo)
-    with pytest.raises(IncompatibleShapeError):
+    with pytest.raises(ValueError, match="shape mismatch: objects cannot be broadcast to a single shape"):
         src.transform_to(ltop)
 
 

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -7,7 +7,7 @@ from astropy.coordinates.representation import (
     UnitSphericalRepresentation,
     CartesianRepresentation,
 )
-from astropy.utils import check_broadcast, exceptions
+from astropy.utils import exceptions
 from astropy.coordinates.baseframe import (
     BaseCoordinateFrame,
     base_doc,
@@ -130,7 +130,7 @@ def make_transform(coo, toframe):
     # Make arrays
     ets = (obstime - _J2000).sec
     stat_ids = np.asarray(location.station_ids)
-    shape_out = check_broadcast(coo.shape, ets.shape, location.shape)
+    shape_out = np.broadcast_shapes(coo.shape, ets.shape, location.shape)
 
     # Set up SPICE ephemerides and frame details
     _spice_setup(location, stat_ids)


### PR DESCRIPTION
This fixes a astropy deprecation warning that is popping up now.

Fixes #33 