### PR TITLE
Fix a bug in the `MoonLocation.__copy__` method when using python 3.14

### DIFF
--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - id: mixed-line-ending
             args: ['--fix=no']
     - repo: https://github.com/pycqa/flake8
-      rev: 3.7.9
+      rev: 7.3.0
       hooks:
       - id: flake8
         additional_dependencies:

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -1,5 +1,4 @@
 import numpy as np
-import copy
 from astropy import units as u
 from astropy.units.quantity import QuantityInfoBase
 from astropy.coordinates.angles import Longitude, Latitude

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -392,13 +392,11 @@ class MoonLocation(u.Quantity):
 
     def copy(self):
         # Necessary to preserve station_ids list
-        c = super().copy()
-        c.station_ids = self.station_ids
-        return c
+        return self.__copy__()
 
     def __copy__(self):
         # Ensure that the station_ids are copied as well under shallow copy
-        obj = copy.copy(super())
+        obj = super().copy()
         obj.station_ids = self.station_ids
         return obj
 

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -98,7 +98,7 @@ def lunar_surface_ephem(pos_x, pos_y, pos_z, station_num=98):
     frame = "MOON_ME"
     degree = 1
 
-    fname = os.path.join(TEMPORARY_KERNEL_DIR.name, f"lunar_points.bsp")
+    fname = os.path.join(TEMPORARY_KERNEL_DIR.name, "lunar_points.bsp")
     if os.path.exists(fname):
         spice.unload(fname)
         handle = spice.spkopa(fname)
@@ -174,7 +174,7 @@ def topo_frame_def(latitude, longitude, station_num=98, moon=True):
         k, v = map(str.strip, spec.split("="))
         frame_dict[k] = v
 
-    latlon = ["{:.4f}".format(l) for l in [latitude, longitude]]
+    latlon = ["{:.4f}".format(coord) for coord in [latitude, longitude]]
 
     return station_name, idnum, frame_dict, latlon
 

--- a/lunarsky/tests/conftest.py
+++ b/lunarsky/tests/conftest.py
@@ -6,6 +6,7 @@ import warnings
 from lunarsky.spice_utils import remove_topo
 from lunarsky.moon import MoonLocation
 
+
 # Ignore deprecation warnings from spiceypy
 @pytest.fixture(autouse=True)
 def ignore_representation_deprecation():


### PR DESCRIPTION
The primary fix is in the `MoonLocation.__copy__` method, which was erroring in python 3.14 with this error message:
```
    def __copy__(self):
        # Ensure that the station_ids are copied as well under shallow copy
        obj = copy.copy(super())
>       obj.station_ids = self.station_ids
        ^^^^^^^^^^^^^^^
E       AttributeError: 'super' object has no attribute 'station_ids' and no __dict__ for setting new attributes

lunarsky/moon.py:402: AttributeError
```

pre-commit errored because of an old version of flake8, so I updated that and made a few fixes required for pre-commit checks to pass. I'd suggest moving to pre-commit CI for linting, partly because it helps you keep these things up to date. Happy to help with that if you're interested.

I also updated the CI to run tests against python 3.13 & 3.14. Not sure whether you want to keep supporting & testing against older versions or not, so I didn't take them out.

