### PR TITLE
Manual kernel download

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ git clone https://github.com/aelanman/lunarsky
 python setup.py install
 ```
 
+Once you've installed lunarsky, you will need to ensure the relevant SPICE kernel files are downloaded
+before running. To do this, run:
+```
+from lunarsky import spice_utils
+spice_utils.download_big_kernels()
+```
+After that, the kernel files will be stored with the package data. This is around 150 MB.
+
 ## Usage
 
 ![mcmf_coords](./docs/figure.png)

--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -464,7 +464,7 @@ class MoonLocation(u.Quantity):
 
     @property
     def lat(self):
-        """Longitude of the location"""
+        """Latitude of the location"""
         return self.selenodetic[1]
 
     @property
@@ -506,7 +506,7 @@ class MoonLocation(u.Quantity):
     mcmf = property(
         get_mcmf,
         doc="""An `~astropy.coordinates.MCMF` object  with
-                                     for the location of this object at the
+                                     or the location of this object at the
                                      default ``obstime``.""",
     )
 

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -72,6 +72,7 @@ def download_big_kernels():
                 chunk_size = max(4096, total_size // 20)
 
             downloaded = 0
+            os.makedirs(os.path.dirname(kf), exist_ok=True)
             with ProgressBar(total_size // chunk_size + 1, ipython_widget=False) as pbar, open(kf, 'wb') as ofile, FileLock(kf + ".lock"):
                 while cur_buf := response.read(chunk_size):
                     downloaded += len(cur_buf)

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -78,6 +78,7 @@ def download_big_kernels():
                     downloaded += len(cur_buf)
                     if total_size > 0:
                         pbar.update(downloaded // chunk_size)
+                    ofile.write(cur_buf)
 
     return paths
 

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -1,7 +1,10 @@
 import numpy as np
 import os
+import urllib.request
+from filelock import FileLock
 import tempfile
-from astropy.utils.data import download_files_in_parallel
+import warnings
+from astropy.utils.console import ProgressBar
 from astropy.coordinates.matrix_utilities import rotation_matrix
 from astropy.time import Time
 import astropy.units as unit
@@ -46,28 +49,59 @@ def list_kernels():
             ktypes.append(dat[1])
     return knames, ktypes
 
+def download_big_kernels():
+    """
+    Download large (~150 MB) spice kernel files that can't be
+    included in the python package.
+
+    Installs them to the package data directory.
+    """
+    # LSK and DE430 Kernels
+    knames = ["lsk/naif0012.tls", "spk/planets/de430.bsp"]
+    _naif_kernel_url = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/"
+    paths = []
+    for kern in knames:
+        kurl = _naif_kernel_url + kern
+        kf = os.path.join(DATA_PATH, kern)
+        paths.append(kf)
+        if os.path.exists(kf):
+            continue
+        with urllib.request.urlopen(kurl) as response:
+            total_size = int(response.headers.get("Content-Length", 0))
+            if total_size > 0:
+                chunk_size = max(4096, total_size // 20)
+
+            downloaded = 0
+            with ProgressBar(total_size // chunk_size + 1, ipython_widget=False) as pbar, open(kf, 'wb') as ofile, FileLock(kf + ".lock"):
+                while cur_buf := response.read(chunk_size):
+                    downloaded += len(cur_buf)
+                    if total_size > 0:
+                        pbar.update(downloaded // chunk_size)
+
+    return paths
 
 def furnish_kernels():
     kernel_names = [
         "pck/moon_pa_de421_1900-2050.bpc",
         "fk/satellites/moon_080317.tf",
         "fk/satellites/moon_assoc_me.tf",
+        "lsk/naif0012.tls",
+        "spk/planets/de430.bsp"
     ]
     kernel_paths = [os.path.join(DATA_PATH, kn) for kn in kernel_names]
+    missing = []
+    for kp in kernel_paths:
+        if not os.path.exists(kp):
+            missing.append(os.path.basename(kp))
+    if len(missing) > 0:
+        warnings.warn(f"Missing kernel file(s). Please run "
+                             "lunarsky.spice_utils.download_big_kernels()")
+        return None
+
     for kp in kernel_paths:
         spice.furnsh(kp)
 
-    # LSK and DE430 Kernels
-    knames = ["lsk/naif0012.tls", "spk/planets/de430.bsp"]
-    _naif_kernel_url = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/"
-    kurls = [_naif_kernel_url + kname for kname in knames]
-    paths = download_files_in_parallel(kurls, cache=True, show_progress=False)
-    for kp in paths:
-        kernel_paths.append(kp)
-        spice.furnsh(kp)
-
     return kernel_paths
-
 
 def lunar_surface_ephem(pos_x, pos_y, pos_z, station_num=98):
     """
@@ -225,6 +259,5 @@ def earth_pos_mcmf(obstimes):
     )
     earthpos = unit.Quantity(earthpos.T, "km")
     return MCMF(*earthpos, obstime=obstimes)
-
 
 KERNEL_PATHS = furnish_kernels()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup_args = {
     "test_suite": "pytest",
     "tests_require": ["pytest"],
     "setup_requires": ["pytest-runner", "setuptools_scm"],
-    "install_requires": ["numpy>=1.15", "astropy>=6.0.0", "spiceypy", "jplephem"],
+    "install_requires": ["numpy>=1.15", "astropy>=6.0.0", "spiceypy", "jplephem", "filelock"],
     "classifiers": [
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,6 @@ setup_args = {
         "write_to": "lunarsky/version.py",
     },
     "include_package_data": True,
-    "package_data":{
-            "lunarsky.data" : ["lunarsky/data/*"],
-            "lunarsky.tests": [],
-     },
     "test_suite": "pytest",
     "tests_require": ["pytest"],
     "setup_requires": ["pytest-runner", "setuptools_scm"],

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ setup_args = {
         "write_to": "lunarsky/version.py",
     },
     "include_package_data": True,
+    "package_data":{
+            "lunarsky.data" : ["lunarsky/data/*"],
+            "lunarsky.tests": [],
+     },
     "test_suite": "pytest",
     "tests_require": ["pytest"],
     "setup_requires": ["pytest-runner", "setuptools_scm"],


### PR DESCRIPTION
Do not automatically download large kernel files the first time the package is imported.

Someone may want a feature that doesn't require the kernels, so that should only be done when needed.

This will not break existing installations, but will change how the code must be used after being freshly installed.