### PR TITLE
set multiprocessing start method for MacOS

### DIFF
--- a/lunarsky/__init__.py
+++ b/lunarsky/__init__.py
@@ -3,7 +3,8 @@ import sys
 if sys.platform == "darwin":
     # On MacOS, need to set multiprocessing to fork by default
     import multiprocessing
-    multiprocessing.set_start_method('fork', force=True)
+
+    multiprocessing.set_start_method("fork", force=True)
 
 from .moon import *  # noqa
 from .mcmf import *  # noqa

--- a/lunarsky/__init__.py
+++ b/lunarsky/__init__.py
@@ -1,3 +1,10 @@
+import sys
+
+if sys.platform == "darwin":
+    # On MacOS, need to set multiprocessing to fork by default
+    import multiprocessing
+    multiprocessing.set_start_method('fork', force=True)
+
 from .moon import *  # noqa
 from .mcmf import *  # noqa
 from .topo import *  # noqa


### PR DESCRIPTION
Closes #47 .

Downloading kernel files fails on MacOS because astropy's downloader uses `multiprocessing`, which defaults to `spawn` on Macs vs. `fork` on linux. This ensures that the fork method is set once the package is imported.

This will not be needed once we've #46 , but fixes an issue for now.