### PR TITLE
Drop support for Python 3.8-3.11

### DIFF
--- a/.github/workflows/pypirelease.yaml
+++ b/.github/workflows/pypirelease.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.12
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV_NAME: linting
-      PYTHON: 3.8
+      PYTHON: 3.12
     steps:
       - uses: actions/checkout@v3
         with:
          fetch-depth: 1
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Setup Environment
         run: |
           pip install pre-commit
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
       rev: 22.3.0
       hooks:
           - id: black
-            language_version: python3.9
+            language_version: python3.12
             args:
               - --line-length=90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "spiceypy",
     "jplephem",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dynamic = [ "version" ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`zipfile.Path.glob` is [broken in Python < 3.12](https://github.com/aelanman/lunarsky/actions/runs/25751281482/job/75628036410?pr=50).

According to [SPEC-0](https://scientific-python.org/specs/spec-0000/), scientific Python packages should only be supporting Python >= 3.12 at this point.