### PR TITLE
fix: use older iterdir instead of glob to ensure backwards compatibility

### DIFF
--- a/lunarsky/moon.py
+++ b/lunarsky/moon.py
@@ -183,7 +183,7 @@ def _get_sites(cache=False):
         cache=cache,
     ) as downloaded:
         path = zipfile.Path(downloaded)
-        (kml_path,) = path.glob("*.kml")
+        (kml_path,) = [s for s in path.iterdir() if s.name.endswith("kml")]
         with kml_path.open() as kml_file:
             kml = KML.parse(kml_file)
 


### PR DESCRIPTION
zipfile.Path.glob wasn't introduced until python 3.12, and we want to maintain support for older versions.