### PR TITLE
set minimum python version to 3.9

### DIFF
--- a/.github/workflows/pypirelease.yaml
+++ b/.github/workflows/pypirelease.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV_NAME: linting
-      PYTHON: 3.8
+      PYTHON: 3.9
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+## Changed
+- Dropped support for Python 3.8
+
 ## [1.0.1] -- 2026-06-16
 
 ## Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "jplephem",
     "fastkml[lxml]",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = [ "version" ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Build relies on setuptools >= 77, but setuptools dropped support for 3.8.