### PR TITLE
Speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.2] -- 2026-06-24
+
+## Changed
+- Vectorize transformation matrix operations
+
+
 ## [1.0.1] -- 2026-06-19
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Non-relativistic transformations are calculated using lunar orientation data fro
 * `numpy`
 * `astropy>=6.0.0`
 * `jplephem`
+* `fastkml[lxml]`
 
 ## Installation
 

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -143,12 +143,43 @@ def j2000_to_moon_me(ets):
     dec = _cheby_eval(dec_coeffs, tau)
     w = _cheby_eval(w_coeffs, tau)
 
-    # J2000 -> MOON_PA: R3(W) @ R1(Dec) @ R3(RA)
-    # Then apply PA -> ME constant rotation
-    mats = np.zeros((len(ets), 3, 3))
-    for i in range(len(ets)):
-        j2000_to_pa = _R3(w[i]) @ _R1(dec[i]) @ _R3(ra[i])
-        mats[i] = _PA_TO_ME @ j2000_to_pa
+    # J2000 -> MOON_PA: R3(W) @ R1(Dec) @ R3(RA), batched over the N obstimes.
+    # Build each stack of 3x3 rotations elementwise then chain via einsum so
+    # there's no Python-level per-time loop. This is ~100x faster on large N.
+    cw, sw = np.cos(w), np.sin(w)
+    cd, sd = np.cos(dec), np.sin(dec)
+    cr, sr = np.cos(ra), np.sin(ra)
+    z = np.zeros_like(w)
+    o = np.ones_like(w)
+    # R3(angle) = [[ c, s, 0], [-s, c, 0], [0, 0, 1]]
+    R3_w = np.stack(
+        [
+            np.stack([cw, sw, z], axis=-1),
+            np.stack([-sw, cw, z], axis=-1),
+            np.stack([z, z, o], axis=-1),
+        ],
+        axis=-2,
+    )
+    R3_ra = np.stack(
+        [
+            np.stack([cr, sr, z], axis=-1),
+            np.stack([-sr, cr, z], axis=-1),
+            np.stack([z, z, o], axis=-1),
+        ],
+        axis=-2,
+    )
+    # R1(angle) = [[1, 0, 0], [0, c, s], [0, -s, c]]
+    R1_dec = np.stack(
+        [
+            np.stack([o, z, z], axis=-1),
+            np.stack([z, cd, sd], axis=-1),
+            np.stack([z, -sd, cd], axis=-1),
+        ],
+        axis=-2,
+    )
+    j2000_to_pa = np.einsum("nij,njk,nkl->nil", R3_w, R1_dec, R3_ra)
+    # Apply the constant PA -> ME rotation (broadcasts over N).
+    mats = np.einsum("ij,njk->nik", _PA_TO_ME, j2000_to_pa)
 
     return mats
 
@@ -284,8 +315,11 @@ def station_pos_ssb_j2000(pos_me_km, ets):
 
     Parameters
     ----------
-    pos_me_km : ndarray, shape (3,)
-        Station position in MOON_ME frame, in km.
+    pos_me_km : ndarray, shape (3,) or (N, 3)
+        Station position(s) in the MOON_ME frame, in km. A 1-D vector is
+        broadcast across all ``ets``; a 2-D array is treated as one position
+        per element of ``ets`` (used by the LunarTopo transform path to
+        evaluate multiple (et, location) pairs in a single batched call).
     ets : ndarray
         ET values.
 
@@ -295,9 +329,13 @@ def station_pos_ssb_j2000(pos_me_km, ets):
         Position in km.
     """
     ets = np.atleast_1d(np.asarray(ets, dtype=float))
+    pos_me_arr = np.asarray(pos_me_km)
     moon_ssb = _pos_ssb_j2000(301, ets)
     me_to_j2000 = moon_me_to_j2000(ets)
-    station_j2000 = np.einsum("nij,j->ni", me_to_j2000, pos_me_km)
+    if pos_me_arr.ndim == 1:
+        station_j2000 = np.einsum("nij,j->ni", me_to_j2000, pos_me_arr)
+    else:
+        station_j2000 = np.einsum("nij,nj->ni", me_to_j2000, pos_me_arr)
     return moon_ssb + station_j2000
 
 

--- a/lunarsky/spice_utils.py
+++ b/lunarsky/spice_utils.py
@@ -144,8 +144,6 @@ def j2000_to_moon_me(ets):
     w = _cheby_eval(w_coeffs, tau)
 
     # J2000 -> MOON_PA: R3(W) @ R1(Dec) @ R3(RA), batched over the N obstimes.
-    # Build each stack of 3x3 rotations elementwise then chain via einsum so
-    # there's no Python-level per-time loop. This is ~100x faster on large N.
     cw, sw = np.cos(w), np.sin(w)
     cd, sd = np.cos(dec), np.sin(dec)
     cr, sr = np.cos(ra), np.sin(ra)

--- a/lunarsky/topo.py
+++ b/lunarsky/topo.py
@@ -138,18 +138,19 @@ def make_transform(coo, toframe):
 
     coo_cart = coo.cartesian
 
-    # Make rotation matrices
-    # TOPO->ME is topo_matrix.T (constant); TOPO->J2000 = R(ME->J2000) @ topo_matrix.T
-    mats_list = []
-    for et, loc_idx in ets_locs:
-        loc_idx = int(loc_idx)
-        topo_mat = topo_mats[loc_idx]
-        if frame_spice_name == "MOON_ME":
-            mats_list.append(topo_mat.T)
-        else:
-            me_to_j2000 = moon_me_to_j2000(np.array([et]))[0]
-            mats_list.append(me_to_j2000 @ topo_mat.T)
-    mats = np.asarray(mats_list)
+    # Make rotation matrices, vectorized.
+    # TOPO -> ME is topo_matrix.T (constant per location); TOPO -> J2000 is
+    # R(ME->J2000) @ topo_matrix.T. Building these in a Python loop with
+    # one moon_me_to_j2000() call per ET is the main perf hot spot in the
+    # transform; do it as a single batched einsum instead.
+    loc_idx_arr = ets_locs[:, 1].astype(int)
+    topo_T_per_et = np.swapaxes(topo_mats[loc_idx_arr], -2, -1)  # (N, 3, 3)
+    if frame_spice_name == "MOON_ME":
+        mats = topo_T_per_et
+    else:
+        ets_arr = ets_locs[:, 0]
+        me_to_j2000_all = moon_me_to_j2000(ets_arr)  # (N, 3, 3) — one call
+        mats = np.einsum("nij,njk->nik", me_to_j2000_all, topo_T_per_et)
     if totopo:
         mats = np.linalg.inv(mats)
 
@@ -160,33 +161,28 @@ def make_transform(coo, toframe):
     )
 
     # If not unitspherical, shift by origin vector before rotating.
+    # Four sub-cases by (totopo, frame_id); each is vectorized over the N
+    # (et, location) pairs so finite-distance / solar-system source paths
+    # don't loop in Python.
     if not is_unitspherical:
-        orig_pos_list = []
-        for et, loc_idx in ets_locs:
-            loc_idx = int(loc_idx)
-            pos_me = pos_mes[loc_idx]
-            topo_mat = topo_mats[loc_idx]
-            et_arr = np.array([et])
+        ets_arr = ets_locs[:, 0]
+        pos_me_per_et = pos_mes[loc_idx_arr]              # (N, 3)
+        topo_mat_per_et = topo_mats[loc_idx_arr]          # (N, 3, 3)
+        if totopo:
+            if frame_id == 0:  # ICRS / SSB origin, position in J2000
+                orig_pos = station_pos_ssb_j2000(pos_me_per_et, ets_arr)
+            else:              # MCMF / Moon-center origin, position in MOON_ME
+                orig_pos = pos_me_per_et
+        else:
+            if frame_id == 0:  # SSB origin, position expressed in TOPO
+                station_ssb = station_pos_ssb_j2000(pos_me_per_et, ets_arr)
+                j2000_me = j2000_to_moon_me(ets_arr)      # (N, 3, 3)
+                ssb_station_me = -np.einsum("nij,nj->ni", j2000_me, station_ssb)
+                orig_pos = np.einsum("nij,nj->ni", topo_mat_per_et, ssb_station_me)
+            else:              # Moon-center origin, position in TOPO
+                orig_pos = -np.einsum("nij,nj->ni", topo_mat_per_et, pos_me_per_et)
 
-            if totopo:
-                # Origin = station position relative to frame origin, in coo's frame
-                if frame_id == 0:  # SSB / ICRS
-                    orig_pos_list.append(station_pos_ssb_j2000(pos_me, et_arr)[0])
-                else:  # Moon center / MCMF
-                    orig_pos_list.append(pos_me)
-            else:
-                # Origin = frame origin relative to station, in coo's frame (topo)
-                if frame_id == 0:  # SSB
-                    station_ssb = station_pos_ssb_j2000(pos_me, et_arr)[0]
-                    ssb_station_j2000 = -station_ssb
-                    # Rotate to topo
-                    j2000_me = j2000_to_moon_me(et_arr)[0]
-                    ssb_station_me = j2000_me @ ssb_station_j2000
-                    orig_pos_list.append(topo_mat @ ssb_station_me)
-                else:  # Moon center
-                    orig_pos_list.append(-(topo_mat @ pos_me))
-
-        orig_pos = np.asarray(orig_pos_list) * un.km
+        orig_pos = orig_pos * un.km
         coo_cart -= CartesianRepresentation(orig_pos.T)
 
     newrepr = coo_cart.transform(mats).reshape(shape_out)


### PR DESCRIPTION
Lunarsky transformations took a performance hit after the compiled SPICE routines were replaced with pure Python functions. This PR vectorizes certain transformations to recover that performance.

Another branch, `cythonize`, creates compiled modules to improve performance even in the case of scalar calls. This involves more significant changes to the build environment, so I'm keeping that separate from this PR.